### PR TITLE
Fix loading multiple environment files

### DIFF
--- a/Program.cpp
+++ b/Program.cpp
@@ -146,6 +146,7 @@ int wmain(int argc, wchar_t *argv[])
             {
                 env = LoadEnvVarsFromFile(envFile);
                 env.insert(currentEnv.begin(), currentEnv.end());
+                currentEnv = env;
             }
         }
 


### PR DESCRIPTION
When loading multiple environment files, currently the variable 'currentEnv' is
not being updated.

We need to update the variable when iterating over the files to load, otherwise
we will end up with only the last environment file being loaded.

Signed-off-by: Ionut Balutoiu <ibalutoiu@cloudbasesolutions.com>